### PR TITLE
Optuna cicv

### DIFF
--- a/conf/ci.yaml
+++ b/conf/ci.yaml
@@ -4,10 +4,3 @@ task: confidence_int
 defaults:
   - _self_
   - defaults
-
-multiple_replications: true
-alpha: 0.05
-error: 0.1
-n: 10
-use_val: false
-less_than_n: 10

--- a/conf/cv.yaml
+++ b/conf/cv.yaml
@@ -4,7 +4,3 @@ task: kfold_cv
 defaults:
   - _self_
   - defaults
-
-multiple_replications: true
-cv_kfold: 5
-cv_kfold_reuse: true

--- a/conf/data/load/hsa_synthetic.yaml
+++ b/conf/data/load/hsa_synthetic.yaml
@@ -21,5 +21,5 @@ data:
     _target_: datasets.load_dataset
     path: json
     data_files:
-      - ${modelhub}/${dataset}/${dataset}.json
+      - ${modelhub}/${dataset}/${fold}${dataset}.json
     streaming: false

--- a/conf/data/load/metabric-dummy.yaml
+++ b/conf/data/load/metabric-dummy.yaml
@@ -21,5 +21,5 @@ data:
     _target_: datasets.load_dataset
     path: csv
     data_files:
-      - ${modelhub}/${dataset}/${dataset}.csv
+      - ${modelhub}/${dataset}/${fold}${dataset}.csv
     streaming: false

--- a/conf/data/load/metabric.yaml
+++ b/conf/data/load/metabric.yaml
@@ -21,5 +21,5 @@ data:
     _target_: datasets.load_dataset
     path: csv
     data_files:
-      - ${modelhub}/${dataset}/${dataset}.csv
+      - ${modelhub}/${dataset}/${fold}${dataset}.csv
     streaming: false

--- a/conf/data/load/metabric_numeric.yaml
+++ b/conf/data/load/metabric_numeric.yaml
@@ -21,5 +21,5 @@ data:
     _target_: datasets.load_dataset
     path: json
     data_files:
-      - ${modelhub}/${dataset}/${dataset}.json
+      - ${modelhub}/${dataset}/${fold}${dataset}.json
     streaming: false

--- a/conf/data/load/seer.yaml
+++ b/conf/data/load/seer.yaml
@@ -21,5 +21,5 @@ data:
     _target_: datasets.load_dataset
     path: json
     data_files:
-      - ${modelhub}/${dataset}/${dataset}.json
+      - ${modelhub}/${dataset}/${fold}${dataset}.json
     streaming: false

--- a/conf/data/load/synthetic.yaml
+++ b/conf/data/load/synthetic.yaml
@@ -21,5 +21,5 @@ data:
     _target_: datasets.load_dataset
     path: json
     data_files:
-      - ${modelhub}/${dataset}/${dataset}.json
+      - ${modelhub}/${dataset}/${fold}${dataset}.json
     streaming: false

--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -33,7 +33,7 @@ pipeline_use_ci: false
 
 # CV config
 multiple_replications: true
-cv_kfold: 5
+cv_kfold: 3
 cv_kfold_reuse: true
 
 # CI config

--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -26,3 +26,19 @@ task_name: sat-${task}-${modelname}-${dataset}-${job}
 
 cv:
   kfold: ${oc.select:cv_kfold,0}
+
+# only one of them can be true. If both are false use fintune directly
+pipeline_use_cv: true
+pipeline_use_ci: false
+
+# CV config
+multiple_replications: true
+cv_kfold: 5
+cv_kfold_reuse: true
+
+# CI config
+alpha: 0.05
+error: 0.1
+n: 10
+use_val: false
+less_than_n: 10

--- a/conf/experiments/metabric_numeric/survival-moco.yaml
+++ b/conf/experiments/metabric_numeric/survival-moco.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 dataset: metabric_numeric
-modelname: survival
+modelname: survival-moco
 
 defaults:
   - metabric_numeric/defaults

--- a/conf/paths/default.yaml
+++ b/conf/paths/default.yaml
@@ -7,7 +7,7 @@ do_data_transform: true
 do_tokenize: true
 do_pretrain: false
 do_finetune: true
-
+fold: ""
 
 # environment variables available when running a job in Azure
 run_id: ${oc.env:AZUREML_RUN_ID, ""}

--- a/conf/sweep/deephit.yaml
+++ b/conf/sweep/deephit.yaml
@@ -31,5 +31,5 @@ optuna:
     _target_: optuna.pruners.MedianPruner
     interval_steps: 5
     n_startup_trials: 5
-    n_warmup_steps: 20
+    n_warmup_steps: 40
   study_overwrite: true

--- a/conf/sweep/metabric/deephit.yaml
+++ b/conf/sweep/metabric/deephit.yaml
@@ -25,7 +25,7 @@ hydra:
     storage: sqlite:///data/model-hub/metabric/deephit/studies.db
     study_name: metabric_deephit
 optuna:
-  metric: [test_ipcw_avg, test_brier_avg]
+  metric: [ipcw.mean, brier.mean]
   metric_direction: [maximize, minimize]
   pruner:
     _target_: optuna.pruners.MedianPruner

--- a/conf/sweep/metabric/survival.yaml
+++ b/conf/sweep/metabric/survival.yaml
@@ -25,7 +25,7 @@ hydra:
     storage: sqlite:///${modelhub}/${dataset}/${modelname}/studies.db
     study_name: ${dataset}_${modelname}
 optuna:
-  metric: [test_ipcw_avg, test_brier_avg]
+  metric: [ipcw.mean, brier.mean]
   metric_direction: [maximize, minimize]
   pruner:
     _target_: optuna.pruners.MedianPruner

--- a/conf/sweep/survival.yaml
+++ b/conf/sweep/survival.yaml
@@ -22,8 +22,8 @@ hydra:
       swapping_prob: 0.5
       constraints_func: null
       seed: ${seed}
-    storage: sqlite:///data/model-hub/metabric/deephit/studies.db
-    study_name: metabric_deephit
+    storage: sqlite:///${modelhub}/${dataset}/${modelname}/studies.db
+    study_name: ${dataset}_${modelname}
 optuna:
   metric: [ipcw.mean, brier.mean]
   metric_direction: [maximize, minimize]
@@ -31,5 +31,5 @@ optuna:
     _target_: optuna.pruners.MedianPruner
     interval_steps: 5
     n_startup_trials: 5
-    n_warmup_steps: 20
+    n_warmup_steps: 40
   study_overwrite: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ seaborn = "^0.13.2"
 hydra-optuna-sweeper = { git = "https://github.com/dahlem/hydra", subdirectory = "plugins/hydra_optuna_sweeper" }
 plotly = "^6.0.1"
 ipython = "^9.0.2"
+glom = "^24.11.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "8.3.5"

--- a/sat/ci.py
+++ b/sat/ci.py
@@ -75,6 +75,8 @@ def _ci(cfg: DictConfig) -> None:
 
         logger.info(f"Saved detailed CI metrics to {outDir}/ci_detailed_metrics.json")
 
+    return ci_results, test_metrics
+
 
 @log_on_start(DEBUG, "Start the ci pipeline...", logger=logger)
 @log_on_error(

--- a/sat/cv.py
+++ b/sat/cv.py
@@ -57,7 +57,7 @@ def _cv(cfg: DictConfig) -> None:
     ipcw = statistics.OnlineStats()
 
     for i in range(cfg.cv.kfold):
-        cfg.dataset = dataset + "_" + str(i)
+        cfg.fold = str(i) + "_"
         logger.info("Run training pipeline")
         metrics, test_metrics = _pipeline(cfg)
 

--- a/sat/cv.py
+++ b/sat/cv.py
@@ -59,7 +59,7 @@ def _cv(cfg: DictConfig) -> None:
     for i in range(cfg.cv.kfold):
         cfg.dataset = dataset + "_" + str(i)
         logger.info("Run training pipeline")
-        metrics, _ = _pipeline(cfg)
+        metrics, test_metrics = _pipeline(cfg)
 
         brier.push(metrics["test_brier_avg"])
         ipcw.push(metrics["test_ipcw_avg"])
@@ -104,6 +104,8 @@ def _cv(cfg: DictConfig) -> None:
             json.dump(prefixed_metrics, fp, indent=4)
 
         logger.info(f"Saved detailed CV metrics to {outDir}/cv_detailed_metrics.json")
+
+    return cv_results, test_metrics
 
 
 @log_on_start(DEBUG, "Start the cv pipeline...", logger=logger)

--- a/sat/data/dataset/parse_hsa_synthetic.py
+++ b/sat/data/dataset/parse_hsa_synthetic.py
@@ -234,13 +234,13 @@ class hsa:
                     index=X_test_kf.index,
                 )
 
-                outDir = Path(f"{self.processed_dir}/{self.name}_{i}")
+                outDir = Path(f"{self.processed_dir}/{self.name}")
                 outDir.mkdir(parents=True, exist_ok=True)
                 data_kf = pd.concat(
                     [train_data_kf, test_data_kf, test_data]
                 ).reset_index(level=0)
                 data_kf.to_json(
-                    Path(f"{outDir}/{self.name}_{i}.json"),
+                    Path(f"{outDir}/{i}_{self.name}.json"),
                     orient="records",
                     lines=True,
                 )

--- a/sat/data/dataset/parse_metabric.py
+++ b/sat/data/dataset/parse_metabric.py
@@ -220,13 +220,13 @@ class metabric:
                         index=X_test_kf.index,
                     )
 
-                    outDir = Path(f"{self.processed_dir}/{self.name}_{i}")
+                    outDir = Path(f"{self.processed_dir}/{self.name}")
                     outDir.mkdir(parents=True, exist_ok=True)
                     data_kf = pd.concat(
                         [train_data_kf, test_data_kf, test_data]
                     ).reset_index(level=0)
                     data_kf.to_csv(
-                        Path(f"{outDir}/{self.name}_{i}.csv"),
+                        Path(f"{outDir}/{i}_{self.name}.csv"),
                         index=False,
                     )
 

--- a/sat/data/dataset/parse_metabric_numerics.py
+++ b/sat/data/dataset/parse_metabric_numerics.py
@@ -253,13 +253,13 @@ class metabric:
                         index=X_test_kf.index,
                     )
 
-                    outDir = Path(f"{self.processed_dir}/{self.name}_{i}")
+                    outDir = Path(f"{self.processed_dir}/{self.name}")
                     outDir.mkdir(parents=True, exist_ok=True)
                     data_kf = pd.concat(
                         [train_data_kf, test_data_kf, test_data]
                     ).reset_index(level=0)
                     data_kf.to_json(
-                        Path(f"{outDir}/{self.name}_{i}.json"),
+                        Path(f"{outDir}/{i}_{self.name}.json"),
                         orient="records",
                         lines=True,
                     )

--- a/sat/data/dataset/parse_seer.py
+++ b/sat/data/dataset/parse_seer.py
@@ -262,13 +262,13 @@ class seer:
                     index=X_test_kf.index,
                 )
 
-                outDir = Path(f"{self.processed_dir}/{self.name}_{i}")
+                outDir = Path(f"{self.processed_dir}/{self.name}")
                 outDir.mkdir(parents=True, exist_ok=True)
                 data_kf = pd.concat(
                     [train_data_kf, test_data_kf, test_data]
                 ).reset_index(level=0)
                 data_kf.to_json(
-                    Path(f"{outDir}/{self.name}_{i}.json"),
+                    Path(f"{outDir}/{i}_{self.name}.json"),
                     orient="records",
                     lines=True,
                 )

--- a/sat/data/dataset/parse_synthetic.py
+++ b/sat/data/dataset/parse_synthetic.py
@@ -160,13 +160,13 @@ class synthetic:
                     index=X_test_kf.index,
                 )
 
-                outDir = Path(f"{self.processed_dir}/{self.name}_{i}")
+                outDir = Path(f"{self.processed_dir}/{self.name}")
                 outDir.mkdir(parents=True, exist_ok=True)
                 data_kf = pd.concat(
                     [train_data_kf, test_data_kf, test_data]
                 ).reset_index(level=0)
                 data_kf.to_json(
-                    Path(f"{outDir}/{self.name}_{i}.json"),
+                    Path(f"{outDir}/{i}_{self.name}.json"),
                     orient="records",
                     lines=True,
                 )

--- a/sat/data/dataset/parse_synthetic_numerics.py
+++ b/sat/data/dataset/parse_synthetic_numerics.py
@@ -268,13 +268,13 @@ class synthetic:
                     index=X_test_kf.index,
                 )
 
-                outDir = Path(f"{self.processed_dir}/{self.name}_{i}")
+                outDir = Path(f"{self.processed_dir}/{self.name}")
                 outDir.mkdir(parents=True, exist_ok=True)
                 data_kf = pd.concat(
                     [train_data_kf, test_data_kf, test_data]
                 ).reset_index(level=0)
                 data_kf.to_json(
-                    Path(f"{outDir}/{self.name}_{i}.json"),
+                    Path(f"{outDir}/{i}_{self.name}.json"),
                     orient="records",
                     lines=True,
                 )

--- a/sat/finetune.py
+++ b/sat/finetune.py
@@ -238,61 +238,6 @@ def _finetune(cfg: DictConfig) -> pd.DataFrame:
         "callbacks": callbacks,
     }
 
-    # Check if we're running as part of an Optuna trial
-    is_optuna_trial = "optuna_trial" in cfg or "optuna_trial_number" in cfg
-
-    # If we have an Optuna trial, add a pruning callback
-    if is_optuna_trial and hasattr(cfg, "optuna"):
-        try:
-            import optuna
-            from hydra.utils import instantiate
-            from optuna.integration import PyTorchLightningPruningCallback
-
-            logger.info("Optuna trial detected - adding pruning callback")
-
-            # Use the metric from the optuna configuration
-            monitor = cfg.optuna.metric
-
-            # Get trial from config
-            trial = cfg.optuna_trial if hasattr(cfg, "optuna_trial") else None
-
-            # Get pruner from config if available
-            pruner = None
-            if hasattr(cfg.optuna, "pruner"):
-                try:
-                    logger.info(f"Instantiating pruner from config")
-                    pruner = instantiate(cfg.optuna.pruner)
-                    logger.info(f"Using pruner: {type(pruner).__name__}")
-                except Exception as e:
-                    logger.warning(
-                        f"Could not instantiate pruner: {e}, using default MedianPruner"
-                    )
-
-            # If we have a trial object but no pruner was configured, apply the pruner
-            if trial is not None and pruner is not None:
-                # Apply pruner to the trial's study if possible
-                try:
-                    if hasattr(trial, "study") and trial.study is not None:
-                        logger.info(f"Setting pruner {type(pruner).__name__} on study")
-                        trial.study.pruner = pruner
-                except Exception as e:
-                    logger.warning(f"Could not set pruner on study: {e}")
-
-            # Create a pruning callback
-            # For Transformers Trainer, we use TorchPruningCallback
-            from optuna.integration import TorchPruningCallback
-
-            # Create a pruning callback
-            pruning_callback = TorchPruningCallback(trial=trial, monitor=monitor)
-
-            # Add to existing callbacks
-            callbacks.append(pruning_callback)
-            logger.info(f"Added Optuna pruning callback monitoring '{monitor}'")
-        except ImportError:
-            logger.warning("Optuna pruning callback not available - skipping")
-        except Exception as e:
-            logger.warning(f"Could not add pruning callback: {e}")
-
     # Create trainer
     if cfg.get(cfg.trainer.custom, False):
         trainer = satrain.SATTrainer(**trainer_kwargs)

--- a/sat/finetune.py
+++ b/sat/finetune.py
@@ -41,11 +41,15 @@ def _finetune(cfg: DictConfig) -> pd.DataFrame:
         torch.autograd.set_detect_anomaly(cfg.detect_anomalies)
 
     logger.debug(f"Loading tokenizer from {cfg.tokenizers.tokenizer_dir}")
-    tokenizer = PreTrainedTokenizerFast(
-        pad_token=cfg.tokenizers.pad_token,
-        mask_token=cfg.tokenizers.mask_token,
-        tokenizer_file=str(Path(f"{cfg.tokenizers.tokenizer_dir}/tokenizer.json")),
-    )
+    try:
+        tokenizer = PreTrainedTokenizerFast(
+            pad_token=cfg.tokenizers.pad_token,
+            mask_token=cfg.tokenizers.mask_token,
+            tokenizer_file=str(Path(f"{cfg.tokenizers.tokenizer_dir}/tokenizer.json")),
+        )
+    except Exception:
+        logger.error(f"Cannot load tokenizer from {cfg.tokenizers.tokenizer_dir}")
+        exit(-1)
 
     logger.debug(f"Loaded tokenizer: {tokenizer} with length {len(tokenizer)}")
     if cfg.token_emb == TokenEmbedding.BERT.value:

--- a/sat/loss/momentum_buffer.py
+++ b/sat/loss/momentum_buffer.py
@@ -164,9 +164,10 @@ class MomentumBuffer:
 
         if rel_change > variance_threshold:
             # Significant increase in variance - need larger buffer
-            logger.info(
-                f"Detected loss instability (variance +{rel_change:.1%}), increasing buffer size"
-            )
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(
+                    f"Detected loss instability (variance +{rel_change:.1%}), increasing buffer size"
+                )
 
             old_size = self.current_buffer_size
             # Increase buffer by 50% up to max size
@@ -187,9 +188,10 @@ class MomentumBuffer:
                     )
                 )
 
-                logger.info(
-                    f"Increased buffer size due to instability: {old_size} → {new_size}"
-                )
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        f"Increased buffer size due to instability: {old_size} → {new_size}"
+                    )
 
         elif len(self.loss_variance_history) >= 5 and rel_change < -variance_threshold:
             # Significant decrease in variance - could reduce buffer to save memory
@@ -218,9 +220,10 @@ class MomentumBuffer:
                     )
                 )
 
-                logger.info(
-                    f"Decreased buffer size due to stability: {old_size} → {new_size}"
-                )
+                if logger.isEnabledFor(logging.DEBUG):
+                    logger.debug(
+                        f"Decreased buffer size due to stability: {old_size} → {new_size}"
+                    )
 
     def update_buffer_size(self, iteration: int):
         """
@@ -257,10 +260,11 @@ class MomentumBuffer:
                 int(self.initial_size * (self.growth_factor**self.current_step)),
             )
 
-        logger.info(
-            f"Increasing buffer size: {old_size} → {self.current_buffer_size} "
-            f"(step {self.current_step}/{self.growth_steps})"
-        )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                f"Increasing buffer size: {old_size} → {self.current_buffer_size} "
+                f"(step {self.current_step}/{self.growth_steps})"
+            )
 
         # Update queue maxlen - need to recreate queues with new size
         self._resize_queues(self.current_buffer_size)
@@ -512,11 +516,12 @@ class MomentumBuffer:
         max_reasonable_size = min(num_samples // 2, 4096)
         recommended_buffer = min(recommended_buffer, max_reasonable_size)
 
-        logger.info(
-            f"Estimated optimal buffer size: {recommended_buffer} "
-            f"(events_per_batch={events_per_batch:.1f}, "
-            f"target={min_events_per_batch})"
-        )
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                f"Estimated optimal buffer size: {recommended_buffer} "
+                f"(events_per_batch={events_per_batch:.1f}, "
+                f"target={min_events_per_batch})"
+            )
 
         return recommended_buffer
 

--- a/sat/optuna_optimize.py
+++ b/sat/optuna_optimize.py
@@ -226,6 +226,7 @@ def optimize(cfg: DictConfig) -> None:
 
     logger.debug("Ensure that we do not use CIs -- too costly")
     cfg.pipeline_use_ci = False
+    cfg.optuna_trial = True
 
     # Check for Optuna sweep parameters
     logger.info("Checking for Optuna sweep parameters in the config:")

--- a/sat/optuna_optimize.py
+++ b/sat/optuna_optimize.py
@@ -68,8 +68,8 @@ def objective(cfg: DictConfig) -> float or tuple:
 
         logger.info(f"Generated new trial number: {trial_number}")
 
-    dataset = cfg.dataset
-    cfg.dataset = dataset + "_trial_" + str(trial_number)
+    modelname = cfg.modelname
+    cfg.modelname = modelname + "_trial_" + str(trial_number)
 
     # Set up output directory for this trial
     trial_dir = Path(cfg.trainer.training_arguments.output_dir)
@@ -224,6 +224,9 @@ def optimize(cfg: DictConfig) -> None:
     logger.info("Full configuration received by optimize function:")
     logger.info(OmegaConf.to_yaml(cfg))
 
+    logger.debug("Ensure that we do not use CIs -- too costly")
+    cfg.pipeline_use_ci = False
+
     # Check for Optuna sweep parameters
     logger.info("Checking for Optuna sweep parameters in the config:")
 
@@ -235,15 +238,6 @@ def optimize(cfg: DictConfig) -> None:
         if "params" in cfg.hydra.sweeper:
             logger.info("Found Hydra sweeper params:")
             logger.info(OmegaConf.to_yaml(cfg.hydra.sweeper.params))
-
-    # # Look for common parameter values directly in root
-    # logger.info("Checking for common parameters in config root:")
-    # for param_name in ["learning_rate", "weight_decay", "num_layers", "hidden_size",
-    #                    "intermediate_size", "num_heads", "batch_size", "activation"]:
-    #     if hasattr(cfg, param_name):
-    #         logger.info(f"Found {param_name} = {getattr(cfg, param_name)}")
-    #     else:
-    #         logger.info(f"Parameter {param_name} not found")
 
     # Look for trial information in configuration
     trial_info = {}

--- a/sat/optuna_optimize.py
+++ b/sat/optuna_optimize.py
@@ -4,6 +4,8 @@ __authors__ = ["Dominik Dahlem"]
 __status__ = "Development"
 
 import os
+import sys
+
 from logging import DEBUG, ERROR
 from pathlib import Path
 
@@ -32,8 +34,6 @@ def objective(cfg: DictConfig) -> float or tuple:
     trial_number = None
 
     # Log all override parameters from Optuna
-    import sys
-
     logger.info("Command line arguments:")
     logger.info(f"  {' '.join(sys.argv)}")
 
@@ -226,7 +226,6 @@ def optimize(cfg: DictConfig) -> None:
 
     logger.debug("Ensure that we do not use CIs -- too costly")
     cfg.pipeline_use_ci = False
-    cfg.optuna_trial = True
 
     # Check for Optuna sweep parameters
     logger.info("Checking for Optuna sweep parameters in the config:")
@@ -266,12 +265,6 @@ def optimize(cfg: DictConfig) -> None:
         logger.info(f"Found trial information: {trial_info}")
     else:
         logger.info("No trial information found in configuration")
-
-    # Check for any command line arguments that might be Optuna params
-    import sys
-
-    logger.info("Command line arguments:")
-    logger.info(f"  {' '.join(sys.argv)}")
 
     return objective(cfg)
 

--- a/sat/optuna_optimize.py
+++ b/sat/optuna_optimize.py
@@ -8,6 +8,7 @@ from logging import DEBUG, ERROR
 from pathlib import Path
 
 import hydra
+from glom import glom
 from logdecorator import log_on_end, log_on_error, log_on_start
 from omegaconf import DictConfig, OmegaConf
 
@@ -132,11 +133,9 @@ def objective(cfg: DictConfig) -> float or tuple:
         missing_metrics = []
 
         for idx, metric_name in enumerate(metric_names):
-            # Check if metric exists in validation or test metrics
-            if metric_name in val_metrics:
-                metric_values.append(val_metrics.get(metric_name))
-            elif metric_name in test_metrics:
-                metric_values.append(test_metrics.get(metric_name))
+            # Check if metric exists in validation
+            if glom(val_metrics, metric_name, default=None) is not None:
+                metric_values.append(glom(val_metrics, metric_name))
             else:
                 missing_metrics.append(metric_name)
                 # Add a bad value based on direction
@@ -148,7 +147,7 @@ def objective(cfg: DictConfig) -> float or tuple:
         if missing_metrics:
             logger.error(
                 f"Trial #{trial_number}: Metrics {missing_metrics} not found in results. Available metrics: "
-                f"val={list(val_metrics.keys())}, test={list(test_metrics.keys())}"
+                f"val={list(val_metrics.keys())}"
             )
 
         # Log the results with trial number


### PR DESCRIPTION
Implemented issue 

Do more consistent design of experiments. The pipeline script now supports running CV, CI, or a single training run. Optuna optimization calls upon the pipeline script and as a consequence can query an average metric. Currently, CI runs are switched off. The default configuration for a sweep looks for the mean c-index and brier index and the pipeline runs 3-fold CV.

**To-Do**: CI reproduces the train/val/test set every time. Instead, it should leave the test set isolated and only recompute the train/val split.